### PR TITLE
Fix: PackageVersion needs to be sent as a parameter override

### DIFF
--- a/samconfig.toml
+++ b/samconfig.toml
@@ -16,7 +16,9 @@ capabilities = "CAPABILITY_IAM"
 tags = [
     "CustomerId=00000"
 ]
-parameter_overrides = []
+parameter_overrides = [
+    "PackageVersion=v1.0.0"
+]
 
 [prod.deploy.parameters]
 region = "us-west-2"
@@ -27,4 +29,6 @@ capabilities = "CAPABILITY_IAM"
 tags = [
     "CustomerId=00000"
 ]
-parameter_overrides = []
+parameter_overrides = [
+    "PackageVersion=v1.0.0"
+]

--- a/template.yaml
+++ b/template.yaml
@@ -15,7 +15,6 @@ Parameters:
     MaxLength: '12'
     AllowedPattern: 'v(\d{1,3})\.(\d{1,3})\.(\d{1,3})'
     ConstraintDescription: must be of the form vX.Y.Z and follow Semantic Versioning 2.0.0
-    Default: v1.0.0
 
 Resources:
   # ---------------- Lambda Layer ---------------- #


### PR DESCRIPTION
For some unknown reason, `sam deploy` does not pick up changes to the PackageVersion parameter if it is used as a Default value in the `template.yaml`. Use PackageVersion as a parameter override in the `samconfig.toml` file