### PR TITLE
Make log streams more configurable

### DIFF
--- a/topshelfsoftware_util/__init__.py
+++ b/topshelfsoftware_util/__init__.py
@@ -7,13 +7,11 @@ from topshelfsoftware_util.json import logger as json_logger
 from topshelfsoftware_util.platform import logger as platform_logger
 
 PACKAGE_NAME = "topshelfsoftware-util"
-LOG_LEVEL = logging.INFO
 
 
 def debug():
     """Set the package Loggers to the DEBUG level."""
-    LOG_LEVEL = logging.DEBUG
-    _set_logger_levels(level=LOG_LEVEL)
+    _set_logger_levels(level=logging.DEBUG)
     return
 
 
@@ -32,7 +30,3 @@ def _set_logger_levels(level: Union[int, str]):
         for handler in logger.handlers:
             handler.setLevel(level)
     return
-
-
-# initialize all package logger levels
-_set_logger_levels(level=LOG_LEVEL)

--- a/topshelfsoftware_util/common.py
+++ b/topshelfsoftware_util/common.py
@@ -5,7 +5,7 @@ import time
 from typing import List, Union
 
 from topshelfsoftware_util.log import get_logger
-logger = get_logger(__name__)
+logger = get_logger(__name__, stream=None)
 
 
 def delay(sec: float):

--- a/topshelfsoftware_util/io.py
+++ b/topshelfsoftware_util/io.py
@@ -7,7 +7,7 @@ from tempfile import gettempdir, mkdtemp
 from typing import Iterator
 
 from topshelfsoftware_util.log import get_logger
-logger = get_logger(__name__)
+logger = get_logger(__name__, stream=None)
 
 
 @contextmanager

--- a/topshelfsoftware_util/json.py
+++ b/topshelfsoftware_util/json.py
@@ -3,7 +3,7 @@
 import json
 
 from topshelfsoftware_util.log import get_logger
-logger = get_logger(__name__)
+logger = get_logger(__name__, stream=None)
 
 
 def fmt_json(input: dict) -> str:

--- a/topshelfsoftware_util/log.py
+++ b/topshelfsoftware_util/log.py
@@ -2,7 +2,7 @@
 
 import logging
 import sys
-from typing import Union
+from typing import TextIO, Union
 
 import coloredlogs
 
@@ -12,18 +12,24 @@ DEFAULT_FMT = "[%(asctime)s] [%(levelname)8s] {%(name)s:%(lineno)d} %(message)s"
 
 def get_logger(name: str,
                level: Union[int, str] = logging.INFO,
+               stream: TextIO = sys.stderr,
                propagate: bool = False) -> logging.Logger:
-    """Configures a logger for modules by setting the log level 
-    and format. Colors the terminal output.
+    """Configures a logger for modules by setting the log level,
+    stream handler and format. Colors the terminal output.
 
     Parameters
     ----------
-    name : str
+    name: str
         The name of the logger to retrieve.
 
-    level : logging._Level, optional
+    level: logging._Level, optional
         The logging level to set the logger.
         Default is `logging.INFO`.
+
+    stream: TextIO, optional
+        The stream where log messages should be written to
+        (a file-like object).
+        Default adds stream to stderr.
 
     propagate: bool, optional
         Determines if logging messages are passed to handlers
@@ -39,8 +45,9 @@ def get_logger(name: str,
     logger = logging.getLogger(name)
     logger.setLevel(level)
     logger.propagate = propagate
-    coloredlogs.install(level=level, logger=logger, stream=sys.stdout,
-                        fmt=DEFAULT_FMT, datefmt=DATE_FMT)
+    if stream is not None:
+        coloredlogs.install(level=level, logger=logger, stream=stream,
+                            fmt=DEFAULT_FMT, datefmt=DATE_FMT)
     return logger
 
 
@@ -69,22 +76,27 @@ def create_console_handler(fmt: str = DEFAULT_FMT,
     return handler
 
 
-def add_console_handler(logger: logging.Logger,
-                        handler: logging.Handler = None) -> None:
-    """Add console handler to the provided logger.
+def add_log_stream(logger: logging.Logger,
+                   level: Union[int, str] = logging.INFO,
+                   stream: TextIO = sys.stderr) -> None:
+    """Send logs to an IO stream.
     
     Parameters
     ----------
     logger: logging.Logger
         An existing logger.
 
-    handler: logging.Handler, optional
-        Handler to add to the provided logger. If none is provided,
-        a StreamHandler will be created and added to the logger.
+    level: logging._Level, optional
+        The logging level to set the logger.
+        Default is `logging.INFO`.
+    
+    stream: TextIO, optional
+        The stream where log messages should be written to
+        (a file-like object).
+        Default adds stream to stderr.
     """
-    if handler is None:
-        handler = create_console_handler()
-    logger.addHandler(handler)
+    coloredlogs.install(level=level, logger=logger, stream=stream,
+                        fmt=DEFAULT_FMT, datefmt=DATE_FMT)
     return
 
 

--- a/topshelfsoftware_util/log.py
+++ b/topshelfsoftware_util/log.py
@@ -51,6 +51,32 @@ def get_logger(name: str,
     return logger
 
 
+def add_log_stream(logger: logging.Logger,
+                   level: Union[int, str] = None,
+                   stream: TextIO = sys.stderr) -> None:
+    """Send logs to an IO stream.
+    
+    Parameters
+    ----------
+    logger: logging.Logger
+        An existing logger.
+
+    level: logging._Level, optional
+        The logging level to set the logger.
+        Default is None, which means use the logger's effective
+        logging level.
+    
+    stream: TextIO, optional
+        The stream where log messages should be written to
+        (a file-like object).
+        Default adds stream to stderr.
+    """
+    level = logger.getEffectiveLevel() if level is None else level
+    coloredlogs.install(level=level, logger=logger, stream=stream,
+                        fmt=DEFAULT_FMT, datefmt=DATE_FMT)
+    return
+
+
 def create_console_handler(fmt: str = DEFAULT_FMT,
                            date_fmt: str = DATE_FMT) -> logging.StreamHandler:
     """Create a formatted stream handler.
@@ -74,30 +100,6 @@ def create_console_handler(fmt: str = DEFAULT_FMT,
     handler = logging.StreamHandler(stream=sys.stdout)
     handler.setFormatter(formatter)
     return handler
-
-
-def add_log_stream(logger: logging.Logger,
-                   level: Union[int, str] = logging.INFO,
-                   stream: TextIO = sys.stderr) -> None:
-    """Send logs to an IO stream.
-    
-    Parameters
-    ----------
-    logger: logging.Logger
-        An existing logger.
-
-    level: logging._Level, optional
-        The logging level to set the logger.
-        Default is `logging.INFO`.
-    
-    stream: TextIO, optional
-        The stream where log messages should be written to
-        (a file-like object).
-        Default adds stream to stderr.
-    """
-    coloredlogs.install(level=level, logger=logger, stream=stream,
-                        fmt=DEFAULT_FMT, datefmt=DATE_FMT)
-    return
 
 
 def clear_root_handlers() -> None:


### PR DESCRIPTION
>Note: These changes are being rolled into v1.0.0 of the package

Allow the option to specify which log stream to use when creating a logger. Also, by default the python utility package loggers will not send logs to any stream. Adopting this design pattern as it more closely follows opt-in behavior - now a caller must opt-in to the package's logs by adding a stream to a particular logger in the package.